### PR TITLE
UserSettings backend code

### DIFF
--- a/generate-token.ts
+++ b/generate-token.ts
@@ -1,0 +1,20 @@
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+// Replace with a valid MongoDB _id from your User collection
+const userPayload = {
+  id: '686eaf3d82b01542e0054462',  // use real ObjectId
+  email: 'testuser@example.com'
+};
+
+const secret = 'Nagaon@123'; // Same as your JWT_SECRET in `.env`
+
+const token = jwt.sign(userPayload, secret, { expiresIn: '1d' });
+
+console.log('🔐 JWT Token for Testing:\n');
+console.log(token);
+console.log('🧪 JWT_SECRET =', process.env.JWT_SECRET);
+
+//Made for testing only

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "class-validator": "^0.14.1",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
-        "express": "^4.18.3",
+        "express": "^4.21.2",
         "graphql": "^15.10.1",
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "class-validator": "^0.14.1",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
-    "express": "^4.18.3",
+    "express": "^4.21.2",
     "graphql": "^15.10.1",
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.2.0",

--- a/src/graphql/index.ts
+++ b/src/graphql/index.ts
@@ -1,9 +1,8 @@
 import { GraphQLSchema, GraphQLObjectType } from 'graphql';
 import { postResolvers } from './resolvers/postResolvers';
 import { userResolvers } from './resolvers/userResolvers';
-import { PostType } from './typeDefs/post.types';
-import { UserType } from './typeDefs/user.types';
 import { friendRequestResolvers } from './resolvers/friendRequestResolvers';
+import { settingsResolvers } from './resolvers/settings.resolver'; // ✅ Add this
 
 // Combine Query
 const RootQuery = new GraphQLObjectType({
@@ -17,9 +16,12 @@ const RootQuery = new GraphQLObjectType({
     users: userResolvers.Query.users,
     me: userResolvers.Query.me,
 
-    // UserSearch and FriendRequest Queries
+    // Friend Request Queries
     searchUsers: friendRequestResolvers.Query.searchUsers,
-    getFriendRequests: friendRequestResolvers.Query.getFriendRequests
+    getFriendRequests: friendRequestResolvers.Query.getFriendRequests,
+
+    // ✅ Settings Query
+    getMySettings: settingsResolvers.Query.getMySettings,
   },
 });
 
@@ -36,9 +38,12 @@ const RootMutation = new GraphQLObjectType({
     // User Mutations
     login: userResolvers.Mutation.login,
 
-    // FriendRequest Mutations
+    // Friend Request Mutations
     sendFriendRequest: friendRequestResolvers.Mutation.sendFriendRequest,
-    respondToFriendRequest: friendRequestResolvers.Mutation.respondToFriendRequest
+    respondToFriendRequest: friendRequestResolvers.Mutation.respondToFriendRequest,
+
+    // ✅ Settings Mutation
+    updateMySettings: settingsResolvers.Mutation.updateMySettings,
   },
 });
 

--- a/src/graphql/resolvers/settings.resolver.ts
+++ b/src/graphql/resolvers/settings.resolver.ts
@@ -1,0 +1,55 @@
+import { GraphQLNonNull } from 'graphql';
+import { User } from '../../models/user.model';
+import {
+  UserSettingsType,
+  UpdateSettingsInput,
+} from '../typeDefs/settings.typeDefs';
+
+type Resolvers = any;
+export const settingsResolvers: Resolvers = {
+  Query: {
+    getMySettings: {
+      type: new GraphQLNonNull(UserSettingsType),
+      resolve: async (
+        _: unknown,
+        __: unknown,
+        context: { user?: { id: string } }
+      ) => {
+        const { user } = context;
+        if (!user) throw new Error('Not authenticated');
+
+        const me = await User.findById(user.id);
+        if (!me) throw new Error('User not found');
+
+        return me.settings;
+      },
+    },
+  },
+
+  Mutation: {
+    updateMySettings: {
+      type: new GraphQLNonNull(UserSettingsType),
+      args: {
+        input: { type: new GraphQLNonNull(UpdateSettingsInput) },
+      },
+      resolve: async (
+        _: unknown,
+        { input }: { input: any }, // (Optional) You can define a custom TypeScript interface here
+        context: { user?: { id: string } }
+      ) => {
+        const { user } = context;
+        if (!user) throw new Error('Not authenticated');
+
+        const updatedUser = await User.findByIdAndUpdate(
+          user.id,
+          { $set: { settings: input } },
+          { new: true }
+        );
+
+        if (!updatedUser) throw new Error('Update failed');
+
+        return updatedUser.settings;
+      },
+    },
+  },
+};

--- a/src/graphql/typeDefs/settings.typeDefs.ts
+++ b/src/graphql/typeDefs/settings.typeDefs.ts
@@ -1,0 +1,55 @@
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLBoolean,
+  GraphQLNonNull,
+  GraphQLInputObjectType,
+} from 'graphql';
+
+/**
+ * Output Type: NotificationPreferences
+ */
+export const NotificationPreferencesType = new GraphQLObjectType({
+  name: 'NotificationPreferences',
+  fields: {
+    friendRequest: { type: new GraphQLNonNull(GraphQLBoolean) },
+    eventInvite: { type: new GraphQLNonNull(GraphQLBoolean) },
+    alumniStatus: { type: new GraphQLNonNull(GraphQLBoolean) },
+  },
+});
+
+/**
+ * Output Type: UserSettings
+ */
+export const UserSettingsType = new GraphQLObjectType({
+  name: 'UserSettings',
+  fields: {
+    profileVisibility: { type: new GraphQLNonNull(GraphQLString) },
+    friendRequestPermission: { type: new GraphQLNonNull(GraphQLString) },
+    notifications: { type: new GraphQLNonNull(NotificationPreferencesType) },
+  },
+});
+
+/**
+ * Input Type: NotificationPreferencesInput
+ */
+export const NotificationPreferencesInput = new GraphQLInputObjectType({
+  name: 'NotificationPreferencesInput',
+  fields: {
+    friendRequest: { type: GraphQLBoolean },
+    eventInvite: { type: GraphQLBoolean },
+    alumniStatus: { type: GraphQLBoolean },
+  },
+});
+
+/**
+ * Input Type: UpdateSettingsInput
+ */
+export const UpdateSettingsInput = new GraphQLInputObjectType({
+  name: 'UpdateSettingsInput',
+  fields: {
+    profileVisibility: { type: GraphQLString },
+    friendRequestPermission: { type: GraphQLString },
+    notifications: { type: NotificationPreferencesInput },
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,16 @@
-import express from 'express';
-import http from 'http';
-import { ApolloServer } from 'apollo-server-express';
-import mongoose from 'mongoose';
-import cors from 'cors';
-import dotenv from 'dotenv';
-import { schema } from './graphql/index';
-import jwt from 'jsonwebtoken';
-import { User } from './models/user.model';
-import { authMiddleware } from './middleware/auth';
+import express from "express";
+import http from "http";
+import { ApolloServer } from "apollo-server-express";
+import 'dotenv/config';
+import mongoose from "mongoose";
+import cors from "cors";
+import dotenv from "dotenv";
+import { schema } from "./graphql/index";
+import jwt from "jsonwebtoken";
+import { User } from "./models/user.model";
+import { authMiddleware } from "./middleware/auth";
+import { Document } from "mongoose";
+import { ApolloServerPluginLandingPageGraphQLPlayground } from "apollo-server-core";
 
 dotenv.config();
 
@@ -17,11 +20,27 @@ app.use(cors());
 app.use(express.json());
 app.use(authMiddleware);
 
-const getUserFromToken = async (token) => {
+interface JwtPayload {
+  userId: string;
+  iat?: number;
+  exp?: number;
+}
+
+interface UserDocument extends Document {
+  _id: string;
+  // Add other user fields as needed
+}
+
+const getUserFromToken = async (
+  token: string
+): Promise<UserDocument | null> => {
   try {
     if (!token) return null;
-    const decoded = jwt.verify(token.replace('Bearer ', ''), process.env.JWT_SECRET);
-    return await User.findById(decoded.userId);
+    const decoded = jwt.verify(
+      token.replace("Bearer ", ""),
+      process.env.JWT_SECRET as string
+    ) as JwtPayload;
+    return (await User.findById(decoded.userId)) as UserDocument | null;
   } catch (err) {
     return null;
   }
@@ -30,17 +49,22 @@ const getUserFromToken = async (token) => {
 const startServer = async () => {
   try {
     // MongoDB Connection
-    await mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/vconnect');
-    console.log('✅ Connected to MongoDB');
+    await mongoose.connect(
+      process.env.MONGODB_URI || "mongodb://localhost:27017/vconnect"
+    );
+    console.log("✅ Connected to MongoDB");
 
     const server = new ApolloServer({
       schema,
       context: async ({ req }) => {
-        const token = req.headers.authorization || '';
+        const token = req.headers.authorization || "";
         const user = await getUserFromToken(token);
         return { user: req.user || null };
       },
-      introspection: true
+      plugins: [
+        ApolloServerPluginLandingPageGraphQLPlayground()
+      ],
+      introspection: true,
     });
 
     await server.start();
@@ -49,10 +73,12 @@ const startServer = async () => {
 
     const PORT = process.env.PORT || 4000;
     app.listen(PORT, () => {
-      console.log(`🚀 Server ready at http://localhost:${PORT}${server.graphqlPath}`);
+      console.log(
+        `🚀 Server ready at http://localhost:${PORT}${server.graphqlPath}`
+      );
     });
   } catch (error) {
-    console.error('❌ Error starting server:', error);
+    console.error("❌ Error starting server:", error);
     process.exit(1);
   }
 };

--- a/src/models/user.model.ts
+++ b/src/models/user.model.ts
@@ -1,20 +1,67 @@
 import mongoose, { Schema, model, Document } from 'mongoose';
 
-export interface IUser extends Document {
-    name: string;
-    email: string;
-    password: string;
-    department: string;
-    batch: string;
-    interests: string[];
-    isAlumni: boolean;
-    profilePicture?: string;
-    friends: mongoose.Types.ObjectId;
-    auth0Id: string; // <-- Add this
-    comparePassword(candidatePassword: string): Promise<boolean>;
+/** ✅ Step 1: Add Settings Interfaces */
+export interface NotificationPreferences {
+  friendRequest: boolean;
+  eventInvite: boolean;
+  alumniStatus: boolean;
 }
 
-const userSchema = new Schema<IUser>({
+export interface UserSettings {
+  profileVisibility: 'public' | 'university' | 'private';
+  friendRequestPermission: 'everyone' | 'university_only' | 'no_one';
+  notifications: NotificationPreferences;
+}
+
+/** ✅ Step 2: IUser Interface including `settings` */
+export interface IUser extends Document {
+  name: string;
+  email: string;
+  password: string;
+  department: string;
+  batch: string;
+  interests: string[];
+  isAlumni: boolean;
+  profilePicture?: string;
+  friends: mongoose.Types.ObjectId[];
+  auth0Id: string;
+  comparePassword(candidatePassword: string): Promise<boolean>;
+  settings: UserSettings;
+}
+
+/** ✅ Step 3: Sub-schemas */
+const notificationPreferencesSchema = new mongoose.Schema(
+  {
+    friendRequest: { type: Boolean, default: true },
+    eventInvite: { type: Boolean, default: true },
+    alumniStatus: { type: Boolean, default: true },
+  },
+  { _id: false }
+);
+
+const settingsSchema = new mongoose.Schema(
+  {
+    profileVisibility: {
+      type: String,
+      enum: ['public', 'university', 'private'],
+      default: 'public',
+    },
+    friendRequestPermission: {
+      type: String,
+      enum: ['everyone', 'university_only', 'no_one'],
+      default: 'everyone',
+    },
+    notifications: {
+      type: notificationPreferencesSchema,
+      default: () => ({}),
+    },
+  },
+  { _id: false }
+);
+
+/** ✅ Step 4: Main User Schema */
+const userSchema = new Schema<IUser>(
+  {
     name: { type: String, required: true },
     email: { type: String, required: false, unique: true },
     password: { type: String, required: false },
@@ -23,13 +70,22 @@ const userSchema = new Schema<IUser>({
     interests: [{ type: String }],
     isAlumni: { type: Boolean, default: false },
     profilePicture: { type: String },
-    friends: [{
+    friends: [
+      {
         type: mongoose.Schema.Types.ObjectId,
-        ref: 'User'
-    }],
-    auth0Id: { type: String, required: true, unique: true }, // <-- Add this
-}, {
+        ref: 'User',
+      },
+    ],
+    settings: {
+      type: settingsSchema,
+      default: () => ({}),
+    },
+    auth0Id: { type: String, required: true, unique: true },
+  },
+  {
     timestamps: true,
-});
+  }
+);
 
+/** ✅ Step 5: Export model */
 export const User = model<IUser>('User', userSchema);


### PR DESCRIPTION
This PR implements the User Settings functionality with GraphQL support.

Changes:
Added settings.typeDefs and settings.resolver to handle:
       getMySettings (Query)
       updateMySettings (Mutation)

Extended the User model with a settings field (including notification preferences).

Integrated settings resolvers into the main GraphQL schema.

Middleware updated to support Auth0-authenticated users.

Notes:
   Only accessible to authenticated users via JWT.
   Tested via Apollo Sandbox with appropriate headers.